### PR TITLE
New parameters for the optimizer

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 --------------------
 
-Copyright 2019 - 2021, Patrick Kunzmann, Benjamin Mayer
+Copyright 2019 - 2022, Patrick Kunzmann, Benjamin Mayer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -71,12 +71,15 @@ In order to increase the quality of the scheme tha amount of optimization steps
 (``--nsteps``) or the number of runs (``--nruns``) can be increased.
 However, increasing these values also extends the runtime of the optimization.
 Note that ``--nruns`` can take advantage of multiple cores.
+The number of used cores is set with ``--nthreads``
 
 The simulated annealing can be adjusted even more fine grained by setting
-the initial reverse temperature (``--beta``) and the rate of its exponential
-growth (``--rate``). The step size decreases in the course of the simulated
+the inverse temperature at the first (``--beta-start``) and last
+(``--beta-end``) step of the optimization.
+For the steps in between the inverse temperature is interpolated exponentially.
+The step size decreases in the course of the simulated
 annealing also in an exponential manner, which can be parameterized via
-``--step-size-start`` and ``--step-size-end``.
+``--stepsize-start`` and ``--stepsize-end``.
 The seed for the random number generator used by the algorithm is set with
 the ``--seed`` option.
 However, these parameters address the more advanced users.

--- a/doc/plotgen.py
+++ b/doc/plotgen.py
@@ -65,7 +65,7 @@ def plot_generator(function):
 def plot_main_example_alignment():
     scheme_file = biotite.temp_file("json")
     gecli.main(args=[
-        "--seed", "0",
+        "--seed", "3",
         "--matrix", "BLOSUM62",
         "--lmin", "60",
         "--lmax", "75",

--- a/doc/theory.rst
+++ b/doc/theory.rst
@@ -173,12 +173,7 @@ an exponential schedule for the step size
 The step size is used for perturbing the current solution in each step of the
 SA algorithm to find a new candidate solution.
 So the idea for using the schedule here is to start with relatively large 
-step size :math:`\delta_{start}` and to chose the rate  according to an 
-target step size :math:`\delta_{end}`.
-An according rate is easily derived  by claiming
-:math:`\delta(N_{max})=\delta_{end}` which leads to
-
-.. math:: \gamma = \frac{1}{N_{max}}\log \left( \frac{\delta_{end}}{\delta_{start}} \right).
+step size and reduce it over the course of the simulation.
  
 
 Monte-Carlo algorithm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gecos"
-version = "1.3.0"
+version = "2.0.0"
 description = "Generated color schemes for sequence alignment visualizations"
 readme = "README.rst"
 license = "BSD-3-Clause"

--- a/src/gecos/__init__.py
+++ b/src/gecos/__init__.py
@@ -2,7 +2,7 @@
 # under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
 # information.
 
-__version__ = "1.3.0"
+__version__ = "2.0.0"
 __author__ = "Patrick Kunzmann"
 
 from .colors import *

--- a/src/gecos/cli.py
+++ b/src/gecos/cli.py
@@ -198,8 +198,15 @@ def main(args=None, result_container=None, show_plots=True):
     )
     opt_group.add_argument(
         "--nruns", default=16, type=int,
-        help="Number of parallel optimization algorithms runs that are to be "
-             "executed.",
+        help="Number of optimizations to run. "
+             "From these runs, the color scheme with the best score is "
+             "selected.",
+        metavar="NUMBER"
+    )
+    opt_group.add_argument(
+        "--nthreads", type=int,
+        help="Number of optimization runs to run in parallel. "
+             "By default this is equal to the number of CPUs.",
         metavar="NUMBER"
     )
     opt_group.add_argument(
@@ -320,7 +327,7 @@ def main(args=None, result_container=None, show_plots=True):
     # Different random seed for each run
     seeds = np.random.randint(0, 1000000, size=args.nruns)
 
-    with Pool(args.nruns) as p:
+    with Pool(args.nthreads) as p:
         results = p.starmap(_optimize, zip(
             seeds,
             itertools.repeat(matrix.get_alphabet1()),

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -393,8 +393,8 @@ class DefaultScoreFunction(ScoreFunction):
     def _calculate_distances(tri_indices, coord, distance_formula):
         ind1, ind2 = tri_indices
         if distance_formula == "CIEDE76":
-            return skimage.color.deltaE_cie76(
-                coord[ind1], coord[ind2]
+            return np.sqrt(
+                np.sum((coord[ind1, :] - coord[ind2, :])**2, axis=-1)
             )
         elif distance_formula == "CIEDE94":
             return skimage.color.deltaE_ciede94(

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -170,43 +170,40 @@ class ColorOptimizer(object):
                  beta_start=1, beta_end=500,
                  stepsize_start=10, stepsize_end=0.2):
         r"""
-        Perform a Simulated Annealing optimization on the current
+        Perform a simulated annealing optimization on the current
         coordinate to minimize the score returned by the score function.
         
-        This is basically a Monte-Carlo optimization where the
-        temperature is varied according to a so called annealing
-        schedule over the course of the optimization. 
+        This is basically a Metropolis-Monte-Carlo optimization where
+        the inverse temperature and step size is varied according to
+        exponential annealing schedule over the course of the
+        optimization.                            
+        
+        Parameters
+        ----------
+        n_steps : int
+            The number of simulated annealing steps.
+        beta_start, beta_end : float
+            The inverse temperature in the first and last step of the
+            optimization, respectively.
+            Higher values allow less increase of score, i.e. result
+            in a steering into the local minimum.
+            Must be positive.
+        stepsize_start, stepsize_end : float
+            The step size in the first and last step of the
+            optimization, respectively.
+            it is the radius in which the coordinates are randomly
+            altered at in each optimization step.
+            Must be positive.
+
+        Notes
+        -----
         The algorithm is a heuristic thats motivated by the physical
         process of annealing.
         If we, e.g., cool steel than a slow cooling can yield a superior
         quality, whereas for a fast cooling the steel can become
         brittle.
         The same happens here within the search space for the given
-        minimization task.                              
-        
-        Parameters
-        ----------
-        n_steps : int
-            The number of Simulated-Annealing steps.
-        beta_start : float
-            The inverse start temperature, where the start temperature
-            would be :math:`T_{start} = 1/(k_b \cdot \beta_{start})` with
-            :math:`k_b` being the boltzmann constant.            
-        rate_beta: float
-            The rate controls how fast the inverse temperature is
-            increased within the annealing schedule.
-            Here the exponential schedule is chosen so we have
-            :math:`\beta (t) = \beta_0 \cdot \exp(rate \cdot t)`.
-        stepsize_start : float
-            The radius in which the coordinates are randomly altered at
-            the beginning of the simulated anneling algorithm.
-            Like the inverse temperature the step size follows an
-            exponential schedule, enabling the algorithm
-            to do large perturbartions at the beginning of the algorithm
-            run and increasingly smaller ones afterwards.
-        stepsize_end : float
-            The radius in which the coordinates are randomly altered at
-            the end of the simulated annealing algorithm run.          
+        minimization task.       
         """
         betas = _calculate_schedule(n_steps, beta_start, beta_end)
         stepsizes = _calculate_schedule(n_steps, stepsize_start, stepsize_end)

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -367,7 +367,7 @@ class DefaultScoreFunction(ScoreFunction):
             self._tri_indices, matrix
         )
         self._contrast = contrast
-        if distance_formula not in ["CIE76", "CIEDE94", "CIEDE2000"]:
+        if distance_formula not in ["CIEDE76", "CIEDE94", "CIEDE2000"]:
             raise ValueError(
                 f"Unknown color distance formula '{distance_formula}'"
             )

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -367,7 +367,7 @@ class DefaultScoreFunction(ScoreFunction):
             self._tri_indices, matrix
         )
         self._contrast = contrast
-        if distance_formula not in ["CIEDE76", "CIEDE94", "CIEDE2000"]:
+        if distance_formula not in ["CIE76", "CIEDE94", "CIEDE2000"]:
             raise ValueError(
                 f"Unknown color distance formula '{distance_formula}'"
             )
@@ -392,7 +392,7 @@ class DefaultScoreFunction(ScoreFunction):
     @staticmethod
     def _calculate_distances(tri_indices, coord, distance_formula):
         ind1, ind2 = tri_indices
-        if distance_formula == "CIEDE76":
+        if distance_formula == "CIE76":
             return np.sqrt(
                 np.sum((coord[ind1, :] - coord[ind2, :])**2, axis=-1)
             )

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -166,8 +166,9 @@ class ColorOptimizer(object):
             score = self._score_func(coord)
         self._scores.append(score)
     
-    def optimize(self, n_steps,
-                 beta_start, beta_end, stepsize_start, stepsize_end):
+    def optimize(self, n_steps=10000,
+                 beta_start=1e-7, beta_end=1e20,
+                 stepsize_start=10, stepsize_end=0.1):
         r"""
         Perform a Simulated Annealing optimization on the current
         coordinate to minimize the score returned by the score function.
@@ -214,7 +215,7 @@ class ColorOptimizer(object):
             score = self._scores[-1]
             new_coord = self._sample_coord(
                 self._coord,
-                lambda c: c + (random.rand(*c.shape)-0.5) * 2 * stepsizes(i)
+                lambda c: c + (random.rand(*c.shape)-0.5) * 2 * stepsizes[i]
             )
             new_score = self._score_func(new_coord)
             
@@ -222,7 +223,7 @@ class ColorOptimizer(object):
                 self._set_coordinates(new_coord, new_score)
                 
             else:
-                p_accept = np.exp( -betas(i) * (new_score-score))
+                p_accept = np.exp( -betas[i] * (new_score-score))
                 if random.rand() <= p_accept:
                     self._set_coordinates(new_coord, new_score)
                 else:

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -166,9 +166,9 @@ class ColorOptimizer(object):
             score = self._score_func(coord)
         self._scores.append(score)
     
-    def optimize(self, n_steps=10000,
-                 beta_start=1e-7, beta_end=1e20,
-                 stepsize_start=10, stepsize_end=0.1):
+    def optimize(self, n_steps=20000,
+                 beta_start=1, beta_end=500,
+                 stepsize_start=10, stepsize_end=0.2):
         r"""
         Perform a Simulated Annealing optimization on the current
         coordinate to minimize the score returned by the score function.

--- a/src/gecos/optimizer.py
+++ b/src/gecos/optimizer.py
@@ -393,18 +393,17 @@ class DefaultScoreFunction(ScoreFunction):
     def _calculate_distances(tri_indices, coord, distance_formula):
         ind1, ind2 = tri_indices
         if distance_formula == "CIEDE76":
-            dist = skimage.color.deltaE_ciede94(
+            return skimage.color.deltaE_cie76(
                 coord[ind1], coord[ind2]
             )
         elif distance_formula == "CIEDE94":
-            dist = skimage.color.deltaE_cie76(
+            return skimage.color.deltaE_ciede94(
                 coord[ind1], coord[ind2]
             )
         else: #"CIEDE2000"
-            dist = skimage.color.deltaE_ciede2000(
+            return skimage.color.deltaE_ciede2000(
                 coord[ind1], coord[ind2]
             )
-        return dist
 
     @staticmethod
     def _calculate_ideal_distances(tri_indices, substitution_matrix):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+# This source code is part of the Gecos package and is distributed
+# under the 3-Clause BSD License. Please see 'LICENSE.rst' for further
+# information.
+
+import pytest
+import inspect
+import gecos
+import gecos.cli as gecli
+
+
+def test_default_args_consistency():
+    """
+    Check whether the default arguments of :meth:`ColorOptimzer.optimize()`
+    match the default parameters of the CLI.
+    """
+    signature = inspect.signature(
+        gecos.ColorOptimizer.optimize
+    )
+    ref_args = {
+        key: val.default for key, val in signature.parameters.items()
+        if val.default is not inspect.Parameter.empty
+    }
+    
+    # Mock that reports whether the given arguments are the defaults
+    def mock_optimize(self, n_steps,
+                 beta_start, beta_end, stepsize_start, stepsize_end):
+        nonlocal ref_args
+        assert n_steps        == ref_args["n_steps"]
+        assert beta_start     == ref_args["beta_start"]
+        assert beta_end       == ref_args["beta_end"]
+        assert stepsize_start == ref_args["stepsize_start"]
+        assert stepsize_end   == ref_args["stepsize_end"]
+    
+    try:
+        # Temporarily replace color optimizer with mock
+        temp = gecos.ColorOptimizer.optimize
+        gecos.ColorOptimizer.optimize = mock_optimize
+        gecli.main(args=[
+            "--seed", "0",
+            "--nruns", "1"
+        ])
+    finally:
+        gecos.ColorOptimizer.optimize = temp

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -87,7 +87,7 @@ def test_optimized_distances():
     matrix = SubstitutionMatrix(alph, alph, np.array(score_matrix))
     # Contrast factor is 0 to optimize only for pairwise distances
     score_func = gecos.DefaultScoreFunction(
-        matrix, contrast=0, distance_formula="CIEDE76"
+        matrix, contrast=0, distance_formula="CIE76"
     )
     ideal_distances = score_func._ideal_dist
     a_to_b_ref, a_to_c_ref, b_to_c_ref = ideal_distances

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -56,7 +56,7 @@ def test_optimization_score():
     score_func = gecos.DefaultScoreFunction(matrix)
     
     optimizer = gecos.ColorOptimizer(alphabet, score_func, space)
-    optimizer.optimize(N_STEPS, 1e-7, 1, 20, 0.1)
+    optimizer.optimize(N_STEPS)
     optimized_score = optimizer.get_result().score
 
     scores = []
@@ -75,8 +75,6 @@ def test_optimized_distances():
     Three symbols can always be arranged optimally, as long as no
     distance is larger than the combined other two distances.
     """
-    N_STEPS = 20000
-
     # Create alphabet with three symbols
     # and a toy substitution matrix for it
     alph = Alphabet(["A", "B", "C"])
@@ -89,7 +87,7 @@ def test_optimized_distances():
     matrix = SubstitutionMatrix(alph, alph, np.array(score_matrix))
     # Contrast factor is 0 to optimize only for pairwise distances
     score_func = gecos.DefaultScoreFunction(
-        matrix, contrast=0, distance_formula="CIE76"
+        matrix, contrast=0, distance_formula="CIEDE76"
     )
     ideal_distances = score_func._ideal_dist
     a_to_b_ref, a_to_c_ref, b_to_c_ref = ideal_distances
@@ -97,7 +95,7 @@ def test_optimized_distances():
     np.random.seed(0)
     space = gecos.ColorSpace()
     optimizer = gecos.ColorOptimizer(alph, score_func, space)
-    optimizer.optimize(N_STEPS, 1e-7, 1, 20, 0.01)
+    optimizer.optimize()
     result = optimizer.get_result()
     optimized_coord = result.lab_colors
     optimized_score = result.score
@@ -141,7 +139,7 @@ def test_constraints(constraint_seed):
     space = gecos.ColorSpace()
     score_func = gecos.DefaultScoreFunction(matrix)
     optimizer = gecos.ColorOptimizer(alph, score_func, space, constraint_pos)
-    optimizer.optimize(N_STEPS, 1e-7, 1, 20, 0.01)
+    optimizer.optimize(N_STEPS)
     result = optimizer.get_result()
     opt_coord = result.lab_colors
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -137,7 +137,7 @@ def test_constraints(constraint_seed):
     )
     constraint_pos[~constraint_mask] = np.nan
 
-    np.random.seed(0)
+    np.random.seed(constraint_seed)
     space = gecos.ColorSpace()
     score_func = gecos.DefaultScoreFunction(matrix)
     optimizer = gecos.ColorOptimizer(alph, score_func, space, constraint_pos)


### PR DESCRIPTION
This PR changes the parameters of `ColorOptimizer.optimize()`:

- `rate_beta` is replaced by `beta_end` to achieve more consistency with `stepsize_start` and `stepsize_end`. The schedule is still exponential.
- All parameters are given default parameters based on best-performing (lowest score after optimization) parameter set, sampled with `Optuna` (see below)
- The default parameters of the CLI are adapted to the new parameters.

Due to the changes of the parameter name and the default arguments for the CLI, the changes are backwards incompatible.
Hence, this PR raises the version to `2.0.0`.

### Meta-optimization

Based on `Optuna`'s [TPESampler](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.TPESampler.html) optimal parameters for `beta_start`, `beta_end`, `stepsize_start` and `stepsize_end` were searched:

![optparam](https://user-images.githubusercontent.com/28051833/171441002-4b6b34ba-1b63-4a82-aa02-537c93f496a7.png)

Each point is a sample and the best-performing sample is marked with '+'.
The found optimal values are:
```
    "beta_start": 1.5730858890829615,
    "beta_end": 345.68453733457994,
    "stepsize_start": 10.5106457598078,
    "stepsize_end": 0.2004581677612361
```
These parameters were rounded and used as default parameters.
Based on the found parameters, the number of steps that give sufficient results was also sampled:

![nsteps](https://user-images.githubusercontent.com/28051833/171441833-1fd7cf8b-1ce7-4cc7-82eb-b8bff114df81.png)

After 20000 steps no considerable improvement is observed. This number of steps is consistent with the current number of steps used by the CLI.

### Benchmark

I also benchmarked the new parameters against the old parameters with the following script. The number of steps was equal for both runs. The old parameters were taken from the CLI, since the previous version of `optimize()` does not provide default values.

```python
import numpy as np
import biotite.sequence as seq
import biotite.sequence.align as align
import gecos

N_RUNS = 20

scores = []
for i in range(N_RUNS):
    np.random.seed(i)
    alph = seq.LetterAlphabet(seq.ProteinSequence.alphabet.get_symbols()[:20])
    matrix = align.SubstitutionMatrix(alph, alph, "BLOSUM62")
    score_func = gecos.DefaultScoreFunction(matrix)
    space = gecos.ColorSpace()
    optimizer = gecos.ColorOptimizer(alph, score_func, space)
    optimizer.optimize(
        ...
    )
    result = optimizer.get_result()
    scores.append(optimizer.get_result().score)
print(f"Median: {np.median(scores):.2f}")
print(f"Mean: {np.mean(scores):.2f}")
print(f"Deviation: {np.std(scores):.2f}")
```

Score for old parameters:
```
Median: 24.38
Mean: 24.51
Deviation: 0.98
```

Score for new parameters:
```
Median: 22.36
Mean: 22.31
Deviation: 0.71
```

I think the new parameter set does not provide large but still significant improvement over the old parameter set.
Furthermore, I think that the new parameters are easier to use, because *beta* and *step size* are handled consistently.
Also changing the number of steps does not influence *beta* and *step size* at the end of the simulation via this change, which is more intuitive in my opinion.

### Further changes

- Fix selection of distance formula if another formula than `CIEDE2000` is chosen
- Add `--nthreads` parameter to CLI to separate number of total runs and number of runs to run in parallel
- Minor code cleanup
- More efficient implementation of `CIE76` formula